### PR TITLE
more powerful succ!

### DIFF
--- a/.local/bin/backup.sh
+++ b/.local/bin/backup.sh
@@ -4,7 +4,7 @@ set -euxo pipefail
 zpool import -o cachefile=none -o altroot=/hdd -N hdd || true
 last_recv=$(zfs list -H -o name -t snapshot -s creation hdd | tail -n 1 | cut -d'@' -f2)
 #new=$(perl -l -e 'print ++$ARGV[0]' $last_recv)
-new=$(ruby -e 'puts ARGV[0].succ' $last_recv)
+new=$(ruby -pe '$_.succ!' <<< $last_recv)
 zfs snapshot -r ssd@$new
 zfs send -R -I $last_recv ssd@$new | zfs recv -Fdu hdd
 backblaze-b2 sync --noProgress --keepDays 30 --threads 8 --replaceNewer /home/pineman/Documents/.zfs/snapshot/$new b2://pineman-Documents


### PR DESCRIPTION
`-p` turns the `-e '$_.succ!'` into

```ruby
while gets  # implicitly sets $_
  $_.succ!  # modifies $_ in place
  print $_
end
```

oh, yes, Ruby is clever enough to make `"a\n".succ == "b\n"` and `"z\n".succ == "aa\n"`.
`gets` doesn't `chomp`.
`print` doen't print a newline at the end.

This saves 4 bytes in your script, maybe 6 if you remove the spaces around the Here String.